### PR TITLE
feat: Implement health data mapping and aggregation functionality

### DIFF
--- a/mobile/lib/core/health/health_data_aggregator.dart
+++ b/mobile/lib/core/health/health_data_aggregator.dart
@@ -1,0 +1,365 @@
+import 'package:dartx/dartx.dart';
+import 'package:flutter_template/core/model/health_data_point.dart';
+import 'package:flutter_template/core/model/health_data_temporal_behavior.dart';
+import 'package:flutter_template/core/model/time_group_by.dart';
+import 'package:flutter_template/model/health_data_unit.dart'
+    hide HealthDataUnit;
+import 'package:health/health.dart';
+
+typedef _AggregationKey = ({HealthDataType type, String? sourceId});
+
+class HealthDataAggregator {
+  const HealthDataAggregator();
+
+  List<AggregatedHealthDataPoint> aggregate({
+    required List<AppHealthDataPoint> data,
+    required TimeGroupBy groupBy,
+    required DateTime startTime,
+    required DateTime endTime,
+    bool aggregatePerSource = true,
+  }) {
+    if (data.isEmpty) return [];
+
+    final timeSegments = _generateTimeSegments(startTime, endTime, groupBy);
+    final aggregatedData = <AggregatedHealthDataPoint>[];
+
+    final healthDataType = HealthDataType.values
+        .firstWhere((type) => type.name == data.first.type);
+    final temporalBehavior =
+        HealthDataTemporalBehavior.forHealthDataType(healthDataType);
+
+    for (int i = 0; i < timeSegments.length - 1; i++) {
+      final segmentStart = timeSegments[i];
+      final segmentEnd = timeSegments[i + 1];
+
+      final aggregatedValue = _aggregateDataForSegment(
+        data,
+        segmentStart,
+        segmentEnd,
+        temporalBehavior,
+        aggregatePerSource,
+      );
+
+      for (final entry in aggregatedValue.entries) {
+        aggregatedData.add(
+          AggregatedHealthDataPoint(
+            type: entry.key.type.name,
+            value: entry.value,
+            unit: entry.key.type.unit.name,
+            dateFrom: segmentStart.toIso8601String(),
+            dateTo: segmentEnd.toIso8601String(),
+            sourceId: entry.key.sourceId,
+          ),
+        );
+      }
+    }
+
+    return aggregatedData;
+  }
+
+  Map<_AggregationKey, double> _aggregateDataForSegment(
+    List<AppHealthDataPoint> data,
+    DateTime segmentStart,
+    DateTime segmentEnd,
+    HealthDataTemporalBehavior temporalBehavior,
+    bool aggregatePerSource,
+  ) {
+    switch (temporalBehavior) {
+      case HealthDataTemporalBehavior.instantaneous:
+        return _aggregateInstantaneousData(
+          data,
+          segmentStart,
+          segmentEnd,
+          aggregatePerSource,
+        );
+      case HealthDataTemporalBehavior.cumulative:
+        return _aggregateCumulativeData(
+          data,
+          segmentStart,
+          segmentEnd,
+          aggregatePerSource,
+        );
+      case HealthDataTemporalBehavior.sessional:
+        return _aggregateSessionalData(
+          data,
+          segmentStart,
+          segmentEnd,
+          aggregatePerSource,
+        );
+      case HealthDataTemporalBehavior.durational:
+        return _aggregateDurationalData(
+          data,
+          segmentStart,
+          segmentEnd,
+          aggregatePerSource,
+        );
+    }
+  }
+
+  Map<_AggregationKey, double> _aggregateInstantaneousData(
+    List<AppHealthDataPoint> data,
+    DateTime segmentStart,
+    DateTime segmentEnd,
+    bool aggregatePerSource,
+  ) {
+    final filteredData = data.where((point) {
+      final pointDate = DateTime.parse(point.dateFrom);
+      return (pointDate.isAfter(segmentStart) ||
+              pointDate.isAtSameMomentAs(segmentStart)) &&
+          pointDate.isBefore(segmentEnd);
+    }).toList();
+
+    return _aggregateValues(filteredData, aggregatePerSource);
+  }
+
+  Map<_AggregationKey, double> _aggregateCumulativeData(
+    List<AppHealthDataPoint> data,
+    DateTime segmentStart,
+    DateTime segmentEnd,
+    bool aggregatePerSource,
+  ) {
+    final totalValue = <_AggregationKey, double>{};
+
+    final dataByKey = data.groupBy(
+      (point) {
+        final type = HealthDataType.values
+            .firstWhere((element) => element.name == point.type);
+        return (
+          type: type,
+          sourceId: aggregatePerSource ? point.sourceId : null
+        );
+      },
+    );
+
+    for (final entry in dataByKey.entries) {
+      final key = entry.key;
+      for (final point in entry.value) {
+        final pointStart = DateTime.parse(point.dateFrom);
+        final pointEnd = DateTime.parse(point.dateTo);
+
+        final overlapStart = _maxDateTime(pointStart, segmentStart);
+        final overlapEnd = _minDateTime(pointEnd, segmentEnd);
+
+        if (overlapStart.isBefore(overlapEnd)) {
+          final pointDuration = pointEnd.difference(pointStart);
+          final overlapDuration = overlapEnd.difference(overlapStart);
+
+          if (pointDuration.inMilliseconds > 0) {
+            final proportion =
+                overlapDuration.inMilliseconds / pointDuration.inMilliseconds;
+            final pointValue = double.tryParse(point.value.toString()) ?? 0.0;
+            totalValue[key] =
+                (totalValue[key] ?? 0.0) + pointValue * proportion;
+          }
+        }
+      }
+    }
+
+    return totalValue;
+  }
+
+  Map<_AggregationKey, double> _aggregateSessionalData(
+    List<AppHealthDataPoint> data,
+    DateTime segmentStart,
+    DateTime segmentEnd,
+    bool aggregatePerSource,
+  ) {
+    final totalValue = <_AggregationKey, double>{};
+
+    final dataByKey = data.groupBy(
+      (point) {
+        final type = HealthDataType.values
+            .firstWhere((element) => element.name == point.type);
+        return (
+          type: type,
+          sourceId: aggregatePerSource ? point.sourceId : null
+        );
+      },
+    );
+
+    for (final entry in dataByKey.entries) {
+      final key = entry.key;
+      for (final point in entry.value) {
+        final pointStart = DateTime.parse(point.dateFrom);
+        final pointEnd = DateTime.parse(point.dateTo);
+
+        final overlapStart = _maxDateTime(pointStart, segmentStart);
+        final overlapEnd = _minDateTime(pointEnd, segmentEnd);
+
+        if (overlapStart.isBefore(overlapEnd)) {
+          final sessionDuration = pointEnd.difference(pointStart);
+          final overlapDuration = overlapEnd.difference(overlapStart);
+
+          if (sessionDuration.inMilliseconds > 0 &&
+              overlapDuration.inMilliseconds >
+                  sessionDuration.inMilliseconds / 2) {
+            final pointValue = double.tryParse(point.value.toString()) ?? 0.0;
+            totalValue[key] = (totalValue[key] ?? 0.0) + pointValue;
+          }
+        }
+      }
+    }
+
+    return totalValue;
+  }
+
+  Map<_AggregationKey, double> _aggregateDurationalData(
+    List<AppHealthDataPoint> data,
+    DateTime segmentStart,
+    DateTime segmentEnd,
+    bool aggregatePerSource,
+  ) {
+    final totalDuration = <_AggregationKey, double>{};
+
+    final dataByKey = data.groupBy(
+      (point) {
+        final type = HealthDataType.values
+            .firstWhere((element) => element.name == point.type);
+        return (
+          type: type,
+          sourceId: aggregatePerSource ? point.sourceId : null
+        );
+      },
+    );
+
+    for (final entry in dataByKey.entries) {
+      final key = entry.key;
+      for (final point in entry.value) {
+        final pointStart = DateTime.parse(point.dateFrom);
+        final pointEnd = DateTime.parse(point.dateTo);
+
+        if (pointEnd.isAfter(segmentStart) &&
+            (pointEnd.isBefore(segmentEnd) ||
+                pointEnd.isAtSameMomentAs(segmentEnd))) {
+          final sessionDuration = pointEnd.difference(pointStart);
+          totalDuration[key] = (totalDuration[key] ?? 0.0) +
+              sessionDuration.inMinutes.toDouble();
+        }
+      }
+    }
+
+    return totalDuration;
+  }
+
+  Map<_AggregationKey, double> _aggregateValues(
+    List<AppHealthDataPoint> dataPoints,
+    bool aggregatePerSource,
+  ) {
+    if (dataPoints.isEmpty) return {};
+
+    final groupedByKey = <_AggregationKey, List<AppHealthDataPoint>>{};
+    for (final point in dataPoints) {
+      final healthType =
+          HealthDataType.values.firstWhere((type) => type.name == point.type);
+      groupedByKey.putIfAbsent(
+        (
+          type: healthType,
+          sourceId: aggregatePerSource ? point.sourceId : null
+        ),
+        () => <AppHealthDataPoint>[],
+      ).add(point);
+    }
+
+    final result = <_AggregationKey, double>{};
+
+    for (final entry in groupedByKey.entries) {
+      final key = entry.key;
+      final typeDataPoints = entry.value;
+
+      double total = 0;
+      for (final point in typeDataPoints) {
+        final value = point.value;
+        if (value is num) {
+          total += value.toDouble();
+        }
+      }
+
+      if (!_isCumulativeDataType(key.type) && typeDataPoints.isNotEmpty) {
+        result[key] = total / typeDataPoints.length;
+      } else {
+        result[key] = total;
+      }
+    }
+
+    return result;
+  }
+
+  bool _isCumulativeDataType(HealthDataType dataType) {
+    const cumulativeTypes = {
+      HealthDataType.STEPS,
+      HealthDataType.DISTANCE_DELTA,
+      HealthDataType.ACTIVE_ENERGY_BURNED,
+      HealthDataType.BASAL_ENERGY_BURNED,
+      HealthDataType.WORKOUT,
+      HealthDataType.WATER,
+      HealthDataType.SLEEP_SESSION,
+      HealthDataType.SLEEP_ASLEEP,
+      HealthDataType.SLEEP_AWAKE,
+      HealthDataType.SLEEP_DEEP,
+      HealthDataType.SLEEP_LIGHT,
+      HealthDataType.SLEEP_REM,
+    };
+
+    return cumulativeTypes.contains(dataType);
+  }
+
+  List<DateTime> _generateTimeSegments(
+    DateTime startTime,
+    DateTime endTime,
+    TimeGroupBy groupBy,
+  ) {
+    final segments = <DateTime>[];
+    var current = _alignToGroupBy(startTime, groupBy);
+
+    while (current.isBefore(endTime)) {
+      segments.add(current);
+      current = _getNextSegment(current, groupBy);
+    }
+
+    if (segments.isEmpty || segments.last.isBefore(endTime)) {
+      segments.add(endTime);
+    }
+
+    return segments;
+  }
+
+  DateTime _alignToGroupBy(DateTime dateTime, TimeGroupBy groupBy) {
+    switch (groupBy) {
+      case TimeGroupBy.hour:
+        return DateTime(
+          dateTime.year,
+          dateTime.month,
+          dateTime.day,
+          dateTime.hour,
+        );
+      case TimeGroupBy.day:
+        return DateTime(dateTime.year, dateTime.month, dateTime.day);
+      case TimeGroupBy.week:
+        final daysToSubtract = dateTime.weekday - 1;
+        return DateTime(
+          dateTime.year,
+          dateTime.month,
+          dateTime.day - daysToSubtract,
+        );
+      case TimeGroupBy.month:
+        return DateTime(dateTime.year, dateTime.month);
+    }
+  }
+
+  DateTime _getNextSegment(DateTime current, TimeGroupBy groupBy) {
+    switch (groupBy) {
+      case TimeGroupBy.hour:
+        return current.add(const Duration(hours: 1));
+      case TimeGroupBy.day:
+        return current.add(const Duration(days: 1));
+      case TimeGroupBy.week:
+        return current.add(const Duration(days: 7));
+      case TimeGroupBy.month:
+        return DateTime(current.year, current.month + 1);
+    }
+  }
+
+  DateTime _maxDateTime(DateTime a, DateTime b) => a.isAfter(b) ? a : b;
+
+  DateTime _minDateTime(DateTime a, DateTime b) => a.isBefore(b) ? a : b;
+}

--- a/mobile/lib/core/health/health_data_mapper.dart
+++ b/mobile/lib/core/health/health_data_mapper.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_template/core/model/health_data_point.dart';
+import 'package:health/health.dart';
+
+class HealthDataMapper {
+  const HealthDataMapper();
+
+  List<AppHealthDataPoint> map(List<HealthDataPoint> dataPoints) => dataPoints
+      .map(
+        (dataPoint) => AppHealthDataPoint.raw(
+          type: dataPoint.type.name,
+          value: _formatHealthValue(dataPoint.value),
+          unit: dataPoint.unit.name,
+          dateFrom: dataPoint.dateFrom.toIso8601String(),
+          dateTo: dataPoint.dateTo.toIso8601String(),
+          sourceId: _extractSourceId(dataPoint),
+        ),
+      )
+      .toList();
+
+  dynamic _formatHealthValue(HealthValue value) {
+    if (value is NumericHealthValue) {
+      return value.numericValue;
+    } else if (value is WorkoutHealthValue) {
+      return {
+        'workoutActivityType': value.workoutActivityType.name,
+        'totalEnergyBurned': value.totalEnergyBurned,
+        'totalDistance': value.totalDistance,
+      };
+    } else if (value is NutritionHealthValue) {
+      return {
+        'calories': value.calories,
+        'protein': value.protein,
+        'carbs': value.carbs,
+        'fat': value.fat,
+      };
+    }
+
+    return value.toString();
+  }
+
+  String? _extractSourceId(HealthDataPoint point) {
+    final candidates = [
+      point.sourceId,
+      point.sourceName,
+      point.sourceDeviceId,
+    ];
+
+    for (final candidate in candidates) {
+      final trimmed = candidate.trim();
+      if (trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+
+    return null;
+  }
+}

--- a/mobile/lib/core/health/health_permissions_guard.dart
+++ b/mobile/lib/core/health/health_permissions_guard.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:flutter_template/core/source/mcp_server.dart';
+import 'package:health/health.dart';
+
+class HealthPermissionsGuard {
+  const HealthPermissionsGuard();
+
+  Future<void> ensurePermissions(
+    Health healthClient,
+    List<HealthDataType> healthTypes,
+  ) async {
+    if (Platform.isAndroid) {
+      await _checkHealthConnectAvailability(healthClient);
+    }
+
+    final hasPermissions = await healthClient.hasPermissions(
+          healthTypes,
+          permissions: healthTypes.map((_) => HealthDataAccess.READ).toList(),
+        ) ??
+        false;
+
+    if (!hasPermissions) {
+      await _requestHealthPermissions(healthClient, healthTypes);
+    }
+
+    await _ensureHistoryAuthorizationIfNeeded(healthClient);
+  }
+
+  Future<void> _checkHealthConnectAvailability(Health healthClient) async {
+    final isAvailable = await healthClient.isHealthConnectAvailable();
+
+    if (!isAvailable) {
+      throw const HealthDataUnavailableException(
+        'Google Health Connect is not available on this device. '
+        'Please install it from the Play Store.',
+      );
+    }
+  }
+
+  Future<void> _requestHealthPermissions(
+    Health healthClient,
+    List<HealthDataType> healthTypes,
+  ) async {
+    final permissionsGranted = await healthClient.requestAuthorization(
+      healthTypes,
+      permissions: healthTypes.map((_) => HealthDataAccess.READ).toList(),
+    );
+
+    if (!permissionsGranted) {
+      throw const HealthPermissionException(
+        'Health permissions not granted. '
+        'Please open Health Connect app and grant permissions manually.',
+      );
+    }
+  }
+
+  Future<void> _ensureHistoryAuthorizationIfNeeded(Health healthClient) async {
+    final isAuthorized = await healthClient.isHealthDataHistoryAuthorized();
+
+    if (!isAuthorized) {
+      await healthClient.requestHealthDataHistoryAuthorization();
+    }
+  }
+}

--- a/mobile/lib/core/health/health_sleep_session_normalizer.dart
+++ b/mobile/lib/core/health/health_sleep_session_normalizer.dart
@@ -50,16 +50,16 @@ class HealthSleepSessionNormalizer {
 
       for (final session in sessions.skip(1)) {
         if (_sessionsOverlapOrAreContinuous(current, session, gapTolerance)) {
-          if (strategy == SleepNormalizationStrategy.preferConsolidated &&
-              _isAlmostContained(
-                current,
-                session,
-                containmentThreshold,
-              )) {
-            current = _selectLongerSession(current, session);
-          } else {
-            current = _mergeSleepSessionPair(current, session);
-          }
+          final preferConsolidated =
+              strategy == SleepNormalizationStrategy.preferConsolidated &&
+                  _isAlmostContained(
+                    current,
+                    session,
+                    containmentThreshold,
+                  );
+          current = preferConsolidated
+              ? _selectLongerSession(current, session)
+              : _mergeSleepSessionPair(current, session);
         } else {
           mergedSessions.add(current);
           current = session;
@@ -79,8 +79,7 @@ class HealthSleepSessionNormalizer {
         point.recordingMethod.name,
       ].join('::');
 
-  HealthDataPoint _cloneSleepSession(HealthDataPoint point) =>
-      HealthDataPoint(
+  HealthDataPoint _cloneSleepSession(HealthDataPoint point) => HealthDataPoint(
         uuid: point.uuid,
         value: point.value is NumericHealthValue
             ? NumericHealthValue(

--- a/mobile/lib/core/health/health_sleep_session_normalizer.dart
+++ b/mobile/lib/core/health/health_sleep_session_normalizer.dart
@@ -1,0 +1,207 @@
+import 'dart:math';
+
+import 'package:dartx/dartx.dart';
+import 'package:health/health.dart';
+
+enum SleepNormalizationStrategy {
+  mergeAdjacent,
+  preferConsolidated,
+}
+
+/// Consolidates overlapping or near-contiguous sleep sessions originating from
+/// the same source into a single interval.
+class HealthSleepSessionNormalizer {
+  const HealthSleepSessionNormalizer();
+
+  List<HealthDataPoint> normalize(
+    List<HealthDataPoint> dataPoints, {
+    SleepNormalizationStrategy strategy =
+        SleepNormalizationStrategy.preferConsolidated,
+    Duration gapTolerance = const Duration(minutes: 5),
+    double containmentThreshold = 0.95,
+  }) {
+    final sleepSessions =
+        dataPoints.where((point) => point.type == HealthDataType.SLEEP_SESSION);
+
+    if (sleepSessions.isEmpty) {
+      return dataPoints;
+    }
+
+    final nonSleepSessions = dataPoints
+        .where((point) => point.type != HealthDataType.SLEEP_SESSION)
+        .toList();
+
+    final mergedSessions = <HealthDataPoint>[];
+
+    // Group by source to avoid mixing sessions coming from different devices
+    // or recording strategies.
+    final sessionsBySource =
+        sleepSessions.groupBy((point) => _buildSourceGroupingKey(point));
+
+    for (final entry in sessionsBySource.entries) {
+      final sessions = entry.value.map(_cloneSleepSession).toList()
+        ..sort((a, b) => a.dateFrom.compareTo(b.dateFrom));
+
+      if (sessions.isEmpty) {
+        continue;
+      }
+
+      var current = sessions.first;
+
+      for (final session in sessions.skip(1)) {
+        if (_sessionsOverlapOrAreContinuous(current, session, gapTolerance)) {
+          if (strategy == SleepNormalizationStrategy.preferConsolidated &&
+              _isAlmostContained(
+                current,
+                session,
+                containmentThreshold,
+              )) {
+            current = _selectLongerSession(current, session);
+          } else {
+            current = _mergeSleepSessionPair(current, session);
+          }
+        } else {
+          mergedSessions.add(current);
+          current = session;
+        }
+      }
+
+      mergedSessions.add(current);
+    }
+
+    return [...nonSleepSessions, ...mergedSessions]
+      ..sort((a, b) => a.dateFrom.compareTo(b.dateFrom));
+  }
+
+  String _buildSourceGroupingKey(HealthDataPoint point) => [
+        point.sourceId,
+        point.sourceDeviceId,
+        point.recordingMethod.name,
+      ].join('::');
+
+  HealthDataPoint _cloneSleepSession(HealthDataPoint point) =>
+      HealthDataPoint(
+        uuid: point.uuid,
+        value: point.value is NumericHealthValue
+            ? NumericHealthValue(
+                numericValue: (point.value as NumericHealthValue).numericValue,
+              )
+            : NumericHealthValue(
+                numericValue:
+                    point.dateTo.difference(point.dateFrom).inSeconds / 60,
+              ),
+        type: point.type,
+        unit: point.unit,
+        dateFrom: point.dateFrom,
+        dateTo: point.dateTo,
+        sourcePlatform: point.sourcePlatform,
+        sourceDeviceId: point.sourceDeviceId,
+        sourceId: point.sourceId,
+        sourceName: point.sourceName,
+        recordingMethod: point.recordingMethod,
+        workoutSummary: point.workoutSummary,
+        metadata: point.metadata != null
+            ? Map<String, dynamic>.from(point.metadata!)
+            : null,
+        deviceModel: point.deviceModel,
+      );
+
+  bool _sessionsOverlapOrAreContinuous(
+    HealthDataPoint current,
+    HealthDataPoint candidate,
+    Duration gapTolerance,
+  ) {
+    final startA = current.dateFrom;
+    final endA = current.dateTo;
+    final startB = candidate.dateFrom;
+    final endB = candidate.dateTo;
+
+    final bool overlaps = startB.isBefore(endA) && endB.isAfter(startA);
+    final bool touches = startB.isAtSameMomentAs(endA);
+
+    if (overlaps || touches) {
+      return true;
+    }
+
+    if (startB.isAfter(endA)) {
+      final gap = startB.difference(endA);
+      return gap <= gapTolerance;
+    }
+
+    return false;
+  }
+
+  bool _isAlmostContained(
+    HealthDataPoint first,
+    HealthDataPoint second,
+    double threshold,
+  ) {
+    final overlapStart = first.dateFrom.isAfter(second.dateFrom)
+        ? first.dateFrom
+        : second.dateFrom;
+    final overlapEnd =
+        first.dateTo.isBefore(second.dateTo) ? first.dateTo : second.dateTo;
+
+    if (!overlapStart.isBefore(overlapEnd)) {
+      return false;
+    }
+
+    final overlapSeconds = overlapEnd.difference(overlapStart).inSeconds;
+    final firstDurationSeconds =
+        max(0, first.dateTo.difference(first.dateFrom).inSeconds);
+    final secondDurationSeconds =
+        max(0, second.dateTo.difference(second.dateFrom).inSeconds);
+
+    final shorterDurationSeconds =
+        min(firstDurationSeconds, secondDurationSeconds);
+
+    if (shorterDurationSeconds == 0) {
+      return false;
+    }
+
+    final coverage = overlapSeconds / shorterDurationSeconds;
+    return coverage >= threshold;
+  }
+
+  HealthDataPoint _selectLongerSession(
+    HealthDataPoint first,
+    HealthDataPoint second,
+  ) {
+    final firstDuration = first.dateTo.difference(first.dateFrom);
+    final secondDuration = second.dateTo.difference(second.dateFrom);
+
+    if (secondDuration > firstDuration) {
+      return second;
+    }
+
+    return first;
+  }
+
+  HealthDataPoint _mergeSleepSessionPair(
+    HealthDataPoint first,
+    HealthDataPoint second,
+  ) {
+    final earliestStart = first.dateFrom.isBefore(second.dateFrom)
+        ? first.dateFrom
+        : second.dateFrom;
+    final latestEnd =
+        first.dateTo.isAfter(second.dateTo) ? first.dateTo : second.dateTo;
+
+    final durationMinutes = latestEnd.difference(earliestStart).inSeconds / 60;
+
+    final mergedMetadata = <String, dynamic>{
+      if (first.metadata != null) ...first.metadata!,
+      if (second.metadata != null) ...second.metadata!,
+    };
+
+    first
+      ..dateFrom = earliestStart
+      ..dateTo = latestEnd
+      ..value = NumericHealthValue(numericValue: durationMinutes)
+      ..unit = HealthDataUnit.MINUTE
+      ..metadata = mergedMetadata.isEmpty ? first.metadata : mergedMetadata
+      ..deviceModel ??= second.deviceModel;
+
+    return first;
+  }
+}

--- a/mobile/lib/core/model/health_data_point.dart
+++ b/mobile/lib/core/model/health_data_point.dart
@@ -11,6 +11,7 @@ class AppHealthDataPoint with _$AppHealthDataPoint {
     required String unit,
     required String dateFrom,
     required String dateTo,
+    required String? sourceId,
   }) = SimpleHealthDataPoint;
 
   const factory AppHealthDataPoint.aggregated({
@@ -19,6 +20,7 @@ class AppHealthDataPoint with _$AppHealthDataPoint {
     required String unit,
     required String dateFrom,
     required String dateTo,
+    required String? sourceId,
   }) = AggregatedHealthDataPoint;
 
   factory AppHealthDataPoint.fromJson(Map<String, dynamic> json) =>

--- a/mobile/lib/core/model/health_data_point.freezed.dart
+++ b/mobile/lib/core/model/health_data_point.freezed.dart
@@ -34,33 +34,34 @@ mixin _$AppHealthDataPoint {
   String get unit => throw _privateConstructorUsedError;
   String get dateFrom => throw _privateConstructorUsedError;
   String get dateTo => throw _privateConstructorUsedError;
+  String? get sourceId => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(String type, dynamic value, String unit,
-            String dateFrom, String dateTo)
+            String dateFrom, String dateTo, String? sourceId)
         raw,
     required TResult Function(String type, double value, String unit,
-            String dateFrom, String dateTo)
+            String dateFrom, String dateTo, String? sourceId)
         aggregated,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(String type, dynamic value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         raw,
     TResult? Function(String type, double value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         aggregated,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(String type, dynamic value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         raw,
     TResult Function(String type, double value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         aggregated,
     required TResult orElse(),
   }) =>
@@ -96,7 +97,12 @@ abstract class $AppHealthDataPointCopyWith<$Res> {
           AppHealthDataPoint value, $Res Function(AppHealthDataPoint) then) =
       _$AppHealthDataPointCopyWithImpl<$Res, AppHealthDataPoint>;
   @useResult
-  $Res call({String type, String unit, String dateFrom, String dateTo});
+  $Res call(
+      {String type,
+      String unit,
+      String dateFrom,
+      String dateTo,
+      String? sourceId});
 }
 
 /// @nodoc
@@ -116,6 +122,7 @@ class _$AppHealthDataPointCopyWithImpl<$Res, $Val extends AppHealthDataPoint>
     Object? unit = null,
     Object? dateFrom = null,
     Object? dateTo = null,
+    Object? sourceId = freezed,
   }) {
     return _then(_value.copyWith(
       type: null == type
@@ -134,6 +141,10 @@ class _$AppHealthDataPointCopyWithImpl<$Res, $Val extends AppHealthDataPoint>
           ? _value.dateTo
           : dateTo // ignore: cast_nullable_to_non_nullable
               as String,
+      sourceId: freezed == sourceId
+          ? _value.sourceId
+          : sourceId // ignore: cast_nullable_to_non_nullable
+              as String?,
     ) as $Val);
   }
 }
@@ -152,7 +163,8 @@ abstract class _$$SimpleHealthDataPointImplCopyWith<$Res>
       dynamic value,
       String unit,
       String dateFrom,
-      String dateTo});
+      String dateTo,
+      String? sourceId});
 }
 
 /// @nodoc
@@ -171,6 +183,7 @@ class __$$SimpleHealthDataPointImplCopyWithImpl<$Res>
     Object? unit = null,
     Object? dateFrom = null,
     Object? dateTo = null,
+    Object? sourceId = freezed,
   }) {
     return _then(_$SimpleHealthDataPointImpl(
       type: null == type
@@ -193,6 +206,10 @@ class __$$SimpleHealthDataPointImplCopyWithImpl<$Res>
           ? _value.dateTo
           : dateTo // ignore: cast_nullable_to_non_nullable
               as String,
+      sourceId: freezed == sourceId
+          ? _value.sourceId
+          : sourceId // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -206,6 +223,7 @@ class _$SimpleHealthDataPointImpl implements SimpleHealthDataPoint {
       required this.unit,
       required this.dateFrom,
       required this.dateTo,
+      required this.sourceId,
       final String? $type})
       : $type = $type ?? 'raw';
 
@@ -222,13 +240,15 @@ class _$SimpleHealthDataPointImpl implements SimpleHealthDataPoint {
   final String dateFrom;
   @override
   final String dateTo;
+  @override
+  final String? sourceId;
 
   @JsonKey(name: 'runtimeType')
   final String $type;
 
   @override
   String toString() {
-    return 'AppHealthDataPoint.raw(type: $type, value: $value, unit: $unit, dateFrom: $dateFrom, dateTo: $dateTo)';
+    return 'AppHealthDataPoint.raw(type: $type, value: $value, unit: $unit, dateFrom: $dateFrom, dateTo: $dateTo, sourceId: $sourceId)';
   }
 
   @override
@@ -241,13 +261,21 @@ class _$SimpleHealthDataPointImpl implements SimpleHealthDataPoint {
             (identical(other.unit, unit) || other.unit == unit) &&
             (identical(other.dateFrom, dateFrom) ||
                 other.dateFrom == dateFrom) &&
-            (identical(other.dateTo, dateTo) || other.dateTo == dateTo));
+            (identical(other.dateTo, dateTo) || other.dateTo == dateTo) &&
+            (identical(other.sourceId, sourceId) ||
+                other.sourceId == sourceId));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, type,
-      const DeepCollectionEquality().hash(value), unit, dateFrom, dateTo);
+  int get hashCode => Object.hash(
+      runtimeType,
+      type,
+      const DeepCollectionEquality().hash(value),
+      unit,
+      dateFrom,
+      dateTo,
+      sourceId);
 
   @JsonKey(ignore: true)
   @override
@@ -260,41 +288,41 @@ class _$SimpleHealthDataPointImpl implements SimpleHealthDataPoint {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(String type, dynamic value, String unit,
-            String dateFrom, String dateTo)
+            String dateFrom, String dateTo, String? sourceId)
         raw,
     required TResult Function(String type, double value, String unit,
-            String dateFrom, String dateTo)
+            String dateFrom, String dateTo, String? sourceId)
         aggregated,
   }) {
-    return raw(type, value, unit, dateFrom, dateTo);
+    return raw(type, value, unit, dateFrom, dateTo, sourceId);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(String type, dynamic value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         raw,
     TResult? Function(String type, double value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         aggregated,
   }) {
-    return raw?.call(type, value, unit, dateFrom, dateTo);
+    return raw?.call(type, value, unit, dateFrom, dateTo, sourceId);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(String type, dynamic value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         raw,
     TResult Function(String type, double value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         aggregated,
     required TResult orElse(),
   }) {
     if (raw != null) {
-      return raw(type, value, unit, dateFrom, dateTo);
+      return raw(type, value, unit, dateFrom, dateTo, sourceId);
     }
     return orElse();
   }
@@ -344,7 +372,8 @@ abstract class SimpleHealthDataPoint implements AppHealthDataPoint {
       required final dynamic value,
       required final String unit,
       required final String dateFrom,
-      required final String dateTo}) = _$SimpleHealthDataPointImpl;
+      required final String dateTo,
+      required final String? sourceId}) = _$SimpleHealthDataPointImpl;
 
   factory SimpleHealthDataPoint.fromJson(Map<String, dynamic> json) =
       _$SimpleHealthDataPointImpl.fromJson;
@@ -359,6 +388,8 @@ abstract class SimpleHealthDataPoint implements AppHealthDataPoint {
   String get dateFrom;
   @override
   String get dateTo;
+  @override
+  String? get sourceId;
   @override
   @JsonKey(ignore: true)
   _$$SimpleHealthDataPointImplCopyWith<_$SimpleHealthDataPointImpl>
@@ -375,7 +406,12 @@ abstract class _$$AggregatedHealthDataPointImplCopyWith<$Res>
   @override
   @useResult
   $Res call(
-      {String type, double value, String unit, String dateFrom, String dateTo});
+      {String type,
+      double value,
+      String unit,
+      String dateFrom,
+      String dateTo,
+      String? sourceId});
 }
 
 /// @nodoc
@@ -396,6 +432,7 @@ class __$$AggregatedHealthDataPointImplCopyWithImpl<$Res>
     Object? unit = null,
     Object? dateFrom = null,
     Object? dateTo = null,
+    Object? sourceId = freezed,
   }) {
     return _then(_$AggregatedHealthDataPointImpl(
       type: null == type
@@ -418,6 +455,10 @@ class __$$AggregatedHealthDataPointImplCopyWithImpl<$Res>
           ? _value.dateTo
           : dateTo // ignore: cast_nullable_to_non_nullable
               as String,
+      sourceId: freezed == sourceId
+          ? _value.sourceId
+          : sourceId // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -431,6 +472,7 @@ class _$AggregatedHealthDataPointImpl implements AggregatedHealthDataPoint {
       required this.unit,
       required this.dateFrom,
       required this.dateTo,
+      required this.sourceId,
       final String? $type})
       : $type = $type ?? 'aggregated';
 
@@ -447,13 +489,15 @@ class _$AggregatedHealthDataPointImpl implements AggregatedHealthDataPoint {
   final String dateFrom;
   @override
   final String dateTo;
+  @override
+  final String? sourceId;
 
   @JsonKey(name: 'runtimeType')
   final String $type;
 
   @override
   String toString() {
-    return 'AppHealthDataPoint.aggregated(type: $type, value: $value, unit: $unit, dateFrom: $dateFrom, dateTo: $dateTo)';
+    return 'AppHealthDataPoint.aggregated(type: $type, value: $value, unit: $unit, dateFrom: $dateFrom, dateTo: $dateTo, sourceId: $sourceId)';
   }
 
   @override
@@ -466,13 +510,15 @@ class _$AggregatedHealthDataPointImpl implements AggregatedHealthDataPoint {
             (identical(other.unit, unit) || other.unit == unit) &&
             (identical(other.dateFrom, dateFrom) ||
                 other.dateFrom == dateFrom) &&
-            (identical(other.dateTo, dateTo) || other.dateTo == dateTo));
+            (identical(other.dateTo, dateTo) || other.dateTo == dateTo) &&
+            (identical(other.sourceId, sourceId) ||
+                other.sourceId == sourceId));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode =>
-      Object.hash(runtimeType, type, value, unit, dateFrom, dateTo);
+      Object.hash(runtimeType, type, value, unit, dateFrom, dateTo, sourceId);
 
   @JsonKey(ignore: true)
   @override
@@ -485,41 +531,41 @@ class _$AggregatedHealthDataPointImpl implements AggregatedHealthDataPoint {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(String type, dynamic value, String unit,
-            String dateFrom, String dateTo)
+            String dateFrom, String dateTo, String? sourceId)
         raw,
     required TResult Function(String type, double value, String unit,
-            String dateFrom, String dateTo)
+            String dateFrom, String dateTo, String? sourceId)
         aggregated,
   }) {
-    return aggregated(type, value, unit, dateFrom, dateTo);
+    return aggregated(type, value, unit, dateFrom, dateTo, sourceId);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function(String type, dynamic value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         raw,
     TResult? Function(String type, double value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         aggregated,
   }) {
-    return aggregated?.call(type, value, unit, dateFrom, dateTo);
+    return aggregated?.call(type, value, unit, dateFrom, dateTo, sourceId);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(String type, dynamic value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         raw,
     TResult Function(String type, double value, String unit, String dateFrom,
-            String dateTo)?
+            String dateTo, String? sourceId)?
         aggregated,
     required TResult orElse(),
   }) {
     if (aggregated != null) {
-      return aggregated(type, value, unit, dateFrom, dateTo);
+      return aggregated(type, value, unit, dateFrom, dateTo, sourceId);
     }
     return orElse();
   }
@@ -569,7 +615,8 @@ abstract class AggregatedHealthDataPoint implements AppHealthDataPoint {
       required final double value,
       required final String unit,
       required final String dateFrom,
-      required final String dateTo}) = _$AggregatedHealthDataPointImpl;
+      required final String dateTo,
+      required final String? sourceId}) = _$AggregatedHealthDataPointImpl;
 
   factory AggregatedHealthDataPoint.fromJson(Map<String, dynamic> json) =
       _$AggregatedHealthDataPointImpl.fromJson;
@@ -584,6 +631,8 @@ abstract class AggregatedHealthDataPoint implements AppHealthDataPoint {
   String get dateFrom;
   @override
   String get dateTo;
+  @override
+  String? get sourceId;
   @override
   @JsonKey(ignore: true)
   _$$AggregatedHealthDataPointImplCopyWith<_$AggregatedHealthDataPointImpl>

--- a/mobile/lib/core/model/health_data_point.g.dart
+++ b/mobile/lib/core/model/health_data_point.g.dart
@@ -14,6 +14,7 @@ _$SimpleHealthDataPointImpl _$$SimpleHealthDataPointImplFromJson(
       unit: json['unit'] as String,
       dateFrom: json['date_from'] as String,
       dateTo: json['date_to'] as String,
+      sourceId: json['source_id'] as String?,
       $type: json['runtimeType'] as String?,
     );
 
@@ -25,6 +26,7 @@ Map<String, dynamic> _$$SimpleHealthDataPointImplToJson(
       'unit': instance.unit,
       'date_from': instance.dateFrom,
       'date_to': instance.dateTo,
+      'source_id': instance.sourceId,
       'runtimeType': instance.$type,
     };
 
@@ -36,6 +38,7 @@ _$AggregatedHealthDataPointImpl _$$AggregatedHealthDataPointImplFromJson(
       unit: json['unit'] as String,
       dateFrom: json['date_from'] as String,
       dateTo: json['date_to'] as String,
+      sourceId: json['source_id'] as String?,
       $type: json['runtimeType'] as String?,
     );
 
@@ -47,5 +50,6 @@ Map<String, dynamic> _$$AggregatedHealthDataPointImplToJson(
       'unit': instance.unit,
       'date_from': instance.dateFrom,
       'date_to': instance.dateTo,
+      'source_id': instance.sourceId,
       'runtimeType': instance.$type,
     };

--- a/mobile/lib/core/service/health_data_manager.dart
+++ b/mobile/lib/core/service/health_data_manager.dart
@@ -1,24 +1,41 @@
-import 'dart:io';
-
 import 'package:dartx/dartx.dart';
+import 'package:flutter_template/core/health/health_data_aggregator.dart';
+import 'package:flutter_template/core/health/health_data_mapper.dart';
+import 'package:flutter_template/core/health/health_permissions_guard.dart';
+import 'package:flutter_template/core/health/health_sleep_session_normalizer.dart';
 import 'package:flutter_template/core/model/aggregation_parameters.dart';
 import 'package:flutter_template/core/model/health_data_point.dart';
 import 'package:flutter_template/core/model/health_data_request.dart';
 import 'package:flutter_template/core/model/health_data_response.dart';
-import 'package:flutter_template/core/model/health_data_temporal_behavior.dart';
 import 'package:flutter_template/core/model/statistic_types.dart';
-import 'package:flutter_template/core/model/time_group_by.dart';
 import 'package:flutter_template/core/source/mcp_server.dart';
-import 'package:flutter_template/model/health_data_unit.dart';
 import 'package:flutter_template/model/vytal_health_data_category.dart';
 import 'package:health/health.dart';
 
 class HealthDataManager {
   HealthDataManager({
     Health? healthClient,
-  }) : _healthClient = healthClient ?? Health();
+    bool aggregatePerSource = true,
+    HealthDataAggregator? healthDataAggregator,
+    HealthDataMapper? healthDataMapper,
+    HealthPermissionsGuard? healthPermissionsGuard,
+    HealthSleepSessionNormalizer? healthSleepSessionNormalizer,
+  })  : _healthClient = healthClient ?? Health(),
+        _aggregatePerSource = aggregatePerSource,
+        _healthDataAggregator =
+            healthDataAggregator ?? const HealthDataAggregator(),
+        _healthDataMapper = healthDataMapper ?? const HealthDataMapper(),
+        _healthPermissionsGuard =
+            healthPermissionsGuard ?? const HealthPermissionsGuard(),
+        _sleepSessionNormalizer = healthSleepSessionNormalizer ??
+            const HealthSleepSessionNormalizer();
 
   final Health _healthClient;
+  final bool _aggregatePerSource;
+  final HealthDataAggregator _healthDataAggregator;
+  final HealthDataMapper _healthDataMapper;
+  final HealthPermissionsGuard _healthPermissionsGuard;
+  final HealthSleepSessionNormalizer _sleepSessionNormalizer;
 
   Future<HealthDataResponse> processHealthDataRequest(
     HealthDataRequest request,
@@ -46,11 +63,12 @@ class HealthDataManager {
       return dataPoints;
     } else {
       final StatisticType? statisticType = request.statistic;
-      final aggregatedData = _aggregateHealthData(
-        dataPoints,
-        groupBy,
-        startTime,
-        endTime,
+      final aggregatedData = _healthDataAggregator.aggregate(
+        data: dataPoints,
+        groupBy: groupBy,
+        startTime: startTime,
+        endTime: endTime,
+        aggregatePerSource: _aggregatePerSource,
       );
 
       switch (statisticType) {
@@ -85,12 +103,18 @@ class HealthDataManager {
     final VytalHealthDataCategory valueType = request.valueType;
 
     _validateTimeRange(startTime, endTime);
-    await ensureHealthPermissions(valueType.platformHealthDataTypes);
+    await _healthPermissionsGuard.ensurePermissions(
+      _healthClient,
+      valueType.platformHealthDataTypes,
+    );
 
     final List<HealthDataPoint> healthDataPoints =
         await _fetchHealthDataPoints(valueType, startTime, endTime);
 
-    return _formatHealthDataPoints(healthDataPoints);
+    final normalizedDataPoints =
+        _normalizeHealthDataPoints(valueType, healthDataPoints);
+
+    return _healthDataMapper.map(normalizedDataPoints);
   }
 
   void _validateTimeRange(DateTime startTime, DateTime endTime) {
@@ -102,61 +126,6 @@ class HealthDataManager {
     if (startTime.isAfter(now)) {
       throw ArgumentError('Start time cannot be in the future');
     }
-  }
-
-  Future<void> checkHealthConnectAvailability() async {
-    final isAvailable = await _healthClient.isHealthConnectAvailable();
-
-    if (!isAvailable) {
-      throw const HealthDataUnavailableException(
-        'Google Health Connect is not available on this device. '
-        'Please install it from the Play Store.',
-      );
-    }
-  }
-
-  Future<void> requestHealthPermissions(
-    List<HealthDataType> healthTypes,
-  ) async {
-    final bool permissionsGranted = await _healthClient.requestAuthorization(
-      healthTypes,
-      permissions: healthTypes.map((_) => HealthDataAccess.READ).toList(),
-    );
-
-    if (!permissionsGranted) {
-      throw const HealthPermissionException(
-        'Health permissions not granted. '
-        'Please open Health Connect app and grant permissions manually.',
-      );
-    }
-  }
-
-  Future<void> ensureHistoryAuthorizationIfNeeded() async {
-    final isAuthorized = await _healthClient.isHealthDataHistoryAuthorized();
-
-    if (!isAuthorized) {
-      await _healthClient.requestHealthDataHistoryAuthorization();
-    }
-  }
-
-  Future<void> ensureHealthPermissions(
-    List<HealthDataType> healthTypes,
-  ) async {
-    if (Platform.isAndroid) {
-      await checkHealthConnectAvailability();
-    }
-
-    final bool hasPermissions = await _healthClient.hasPermissions(
-          healthTypes,
-          permissions: healthTypes.map((_) => HealthDataAccess.READ).toList(),
-        ) ??
-        false;
-
-    if (!hasPermissions) {
-      await requestHealthPermissions(healthTypes);
-    }
-
-    await ensureHistoryAuthorizationIfNeeded();
   }
 
   Future<List<HealthDataPoint>> _fetchHealthDataPoints(
@@ -176,414 +145,73 @@ class HealthDataManager {
     return result;
   }
 
-  List<AppHealthDataPoint> _formatHealthDataPoints(
+  List<HealthDataPoint> _normalizeHealthDataPoints(
+    VytalHealthDataCategory category,
     List<HealthDataPoint> dataPoints,
+  ) {
+    if (category != VytalHealthDataCategory.SLEEP || dataPoints.isEmpty) {
+      return dataPoints;
+    }
+
+    return _sleepSessionNormalizer.normalize(dataPoints);
+  }
+
+  List<AggregatedHealthDataPoint> _buildOverallAverageResponse(
+    HealthDataAggregationParameters aggregationParameters,
+  ) {
+    double totalValue = 0;
+    int totalDataPoints = 0;
+
+    for (final dataPoint in aggregationParameters.aggregatedData) {
+      final value = dataPoint.value;
+      const dataPointCount = 1;
+
+      totalValue += value;
+      totalDataPoints += dataPointCount;
+    }
+
+    final overallAverage = totalDataPoints > 0
+        ? totalValue / aggregationParameters.aggregatedData.length
+        : 0.0;
+
+    return [
+      AggregatedHealthDataPoint(
+        type: aggregationParameters.formattedData.isNotEmpty
+            ? aggregationParameters.formattedData.first.type
+            : 'UNKNOWN',
+        value: overallAverage,
+        unit: aggregationParameters.formattedData.isNotEmpty
+            ? aggregationParameters.formattedData.first.unit
+            : 'NO_UNIT',
+        dateFrom: aggregationParameters.startTime.toIso8601String(),
+        dateTo: aggregationParameters.endTime.toIso8601String(),
+        sourceId: null,
+      ),
+    ];
+  }
+
+  List<AggregatedHealthDataPoint> _buildAggregatedStatisticsResponse(
+    List<AggregatedHealthDataPoint> aggregatedData,
+    StatisticType statisticType,
   ) =>
-      dataPoints
-          .map(
-            (dataPoint) => AppHealthDataPoint.raw(
-              type: dataPoint.type.name,
-              value: _formatHealthValue(dataPoint.value),
-              unit: dataPoint.unit.name,
-              dateFrom: dataPoint.dateFrom.toIso8601String(),
-              dateTo: dataPoint.dateTo.toIso8601String(),
-            ),
-          )
-          .toList();
+      aggregatedData;
 
-  dynamic _formatHealthValue(HealthValue value) {
-    if (value is NumericHealthValue) {
-      return value.numericValue;
-    } else if (value is WorkoutHealthValue) {
-      return {
-        'workoutActivityType': value.workoutActivityType.name,
-        'totalEnergyBurned': value.totalEnergyBurned,
-        'totalDistance': value.totalDistance,
-      };
-    } else if (value is NutritionHealthValue) {
-      return {
-        'calories': value.calories,
-        'protein': value.protein,
-        'carbs': value.carbs,
-        'fat': value.fat,
-      };
-    }
-    return value.toString();
-  }
-
-  List<AggregatedHealthDataPoint> _aggregateHealthData(
-    List<AppHealthDataPoint> data,
-    TimeGroupBy groupBy,
-    DateTime startTime,
-    DateTime endTime,
+  HealthDataResponse _createSuccessResponse(
+    List<AppHealthDataPoint> healthData,
+    HealthDataRequest request,
   ) {
-    if (data.isEmpty) return [];
-
-    final List<DateTime> timeSegments = _generateTimeSegments(
-      startTime,
-      endTime,
-      groupBy,
+    final isAggregated =
+        healthData.all((point) => point is AggregatedHealthDataPoint);
+    return HealthDataResponse(
+      success: true,
+      count: healthData.length,
+      healthData: healthData,
+      valueType: request.valueType.name,
+      startTime: request.startTime.toIso8601String(),
+      endTime: request.endTime.toIso8601String(),
+      groupBy: isAggregated ? request.groupBy?.name : null,
+      isAggregated: isAggregated,
+      statisticType: isAggregated ? request.statistic?.name : null,
     );
-    final List<AggregatedHealthDataPoint> aggregatedData = [];
-
-    final healthDataType = HealthDataType.values.firstWhere(
-      (type) => type.name == data.first.type,
-    );
-    final temporalBehavior =
-        HealthDataTemporalBehavior.forHealthDataType(healthDataType);
-
-    for (int i = 0; i < timeSegments.length - 1; i++) {
-      final DateTime segmentStart = timeSegments[i];
-      final DateTime segmentEnd = timeSegments[i + 1];
-
-      final aggregatedValue = _aggregateDataForSegment(
-        data,
-        segmentStart,
-        segmentEnd,
-        temporalBehavior,
-      );
-
-      for (final entry in aggregatedValue.entries) {
-        aggregatedData.add(
-          AggregatedHealthDataPoint(
-            type: entry.key.name,
-            value: entry.value,
-            unit: entry.key.unit.name,
-            dateFrom: segmentStart.toIso8601String(),
-            dateTo: segmentEnd.toIso8601String(),
-          ),
-        );
-      }
-    }
-
-    return aggregatedData;
   }
-
-  /// Aggregate data for a specific time segment based on temporal behavior
-  Map<HealthDataType, double> _aggregateDataForSegment(
-    List<AppHealthDataPoint> data,
-    DateTime segmentStart,
-    DateTime segmentEnd,
-    HealthDataTemporalBehavior temporalBehavior,
-  ) {
-    switch (temporalBehavior) {
-      case HealthDataTemporalBehavior.instantaneous:
-        return _aggregateInstantaneousData(data, segmentStart, segmentEnd);
-
-      case HealthDataTemporalBehavior.cumulative:
-        return _aggregateCumulativeData(data, segmentStart, segmentEnd);
-
-      case HealthDataTemporalBehavior.sessional:
-        return _aggregateSessionalData(data, segmentStart, segmentEnd);
-
-      case HealthDataTemporalBehavior.durational:
-        return _aggregateDurationalData(data, segmentStart, segmentEnd);
-    }
-  }
-
-  Map<HealthDataType, double> _aggregateInstantaneousData(
-    List<AppHealthDataPoint> data,
-    DateTime segmentStart,
-    DateTime segmentEnd,
-  ) {
-    final filteredData = data.where((point) {
-      final DateTime pointDate = DateTime.parse(point.dateFrom);
-      return (pointDate.isAfter(segmentStart) ||
-              pointDate.isAtSameMomentAs(segmentStart)) &&
-          pointDate.isBefore(segmentEnd);
-    }).toList();
-
-    return _aggregateValues(filteredData);
-  }
-
-  Map<HealthDataType, double> _aggregateCumulativeData(
-    List<AppHealthDataPoint> data,
-    DateTime segmentStart,
-    DateTime segmentEnd,
-  ) {
-    final Map<HealthDataType, double> totalValue = {};
-
-    final dataByType = data.groupBy(
-      (point) =>
-          HealthDataType.values.firstWhere((type) => type.name == point.type),
-    );
-
-    for (final type in dataByType.keys) {
-      for (final point in dataByType[type]!) {
-        final DateTime pointStart = DateTime.parse(point.dateFrom);
-        final DateTime pointEnd = DateTime.parse(point.dateTo);
-
-        final DateTime overlapStart = _maxDateTime(pointStart, segmentStart);
-        final DateTime overlapEnd = _minDateTime(pointEnd, segmentEnd);
-
-        if (overlapStart.isBefore(overlapEnd)) {
-          // Calculate the proportion of the data point within this segment
-          final Duration pointDuration = pointEnd.difference(pointStart);
-          final Duration overlapDuration = overlapEnd.difference(overlapStart);
-
-          if (pointDuration.inMilliseconds > 0) {
-            final double proportion =
-                overlapDuration.inMilliseconds / pointDuration.inMilliseconds;
-            final double pointValue =
-                double.tryParse(point.value.toString()) ?? 0.0;
-            totalValue[type] =
-                (totalValue[type] ?? 0.0) + pointValue * proportion;
-          }
-        }
-      }
-    }
-
-    return totalValue;
-  }
-}
-
-Map<HealthDataType, double> _aggregateSessionalData(
-  List<AppHealthDataPoint> data,
-  DateTime segmentStart,
-  DateTime segmentEnd,
-) {
-  final Map<HealthDataType, double> totalValue = {};
-
-  final dataByType = data.groupBy(
-    (point) =>
-        HealthDataType.values.firstWhere((type) => type.name == point.type),
-  );
-
-  for (final type in dataByType.keys) {
-    for (final point in dataByType[type]!) {
-      final DateTime pointStart = DateTime.parse(point.dateFrom);
-      final DateTime pointEnd = DateTime.parse(point.dateTo);
-
-      final DateTime overlapStart = _maxDateTime(pointStart, segmentStart);
-      final DateTime overlapEnd = _minDateTime(pointEnd, segmentEnd);
-
-      if (overlapStart.isBefore(overlapEnd)) {
-        final Duration sessionDuration = pointEnd.difference(pointStart);
-        final Duration overlapDuration = overlapEnd.difference(overlapStart);
-
-        // If more than 50% of the session is in this segment, assign full value
-        if (sessionDuration.inMilliseconds > 0 &&
-            overlapDuration.inMilliseconds >
-                sessionDuration.inMilliseconds / 2) {
-          final double pointValue =
-              double.tryParse(point.value.toString()) ?? 0.0;
-          totalValue[type] = (totalValue[type] ?? 0.0) + pointValue;
-        }
-      }
-    }
-  }
-
-  return totalValue;
-}
-
-Map<HealthDataType, double> _aggregateDurationalData(
-  List<AppHealthDataPoint> data,
-  DateTime segmentStart,
-  DateTime segmentEnd,
-) {
-  final Map<HealthDataType, double> totalDuration = {};
-
-  final dataByType = data.groupBy(
-    (point) =>
-        HealthDataType.values.firstWhere((type) => type.name == point.type),
-  );
-
-  for (final type in dataByType.keys) {
-    for (final point in dataByType[type]!) {
-      final DateTime pointStart = DateTime.parse(point.dateFrom);
-      final DateTime pointEnd = DateTime.parse(point.dateTo);
-
-      // For sleep sessions, assign the full duration to the segment
-      // containing the END time
-      // This way "slept 10 hours" appears on the day you wake up,
-      // not distributed
-      if (pointEnd.isAfter(segmentStart) &&
-          (pointEnd.isBefore(segmentEnd) ||
-              pointEnd.isAtSameMomentAs(segmentEnd))) {
-        final Duration sessionDuration = pointEnd.difference(pointStart);
-        totalDuration[type] =
-            (totalDuration[type] ?? 0.0) + sessionDuration.inMinutes.toDouble();
-      }
-    }
-  }
-
-  return totalDuration;
-}
-
-/// Utility: Get the maximum of two DateTimes
-DateTime _maxDateTime(DateTime a, DateTime b) => a.isAfter(b) ? a : b;
-
-/// Utility: Get the minimum of two DateTimes
-DateTime _minDateTime(DateTime a, DateTime b) => a.isBefore(b) ? a : b;
-
-List<DateTime> _generateTimeSegments(
-  DateTime startTime,
-  DateTime endTime,
-  TimeGroupBy groupBy,
-) {
-  final List<DateTime> segments = [];
-  DateTime current = _alignToGroupBy(startTime, groupBy);
-
-  while (current.isBefore(endTime)) {
-    segments.add(current);
-    current = _getNextSegment(current, groupBy);
-  }
-
-  if (segments.isEmpty || segments.last.isBefore(endTime)) {
-    segments.add(endTime);
-  }
-
-  return segments;
-}
-
-DateTime _alignToGroupBy(DateTime dateTime, TimeGroupBy groupBy) {
-  switch (groupBy) {
-    case TimeGroupBy.hour:
-      return DateTime(
-        dateTime.year,
-        dateTime.month,
-        dateTime.day,
-        dateTime.hour,
-      );
-    case TimeGroupBy.day:
-      return DateTime(dateTime.year, dateTime.month, dateTime.day);
-    case TimeGroupBy.week:
-      final int daysToSubtract = dateTime.weekday - 1;
-      return DateTime(
-        dateTime.year,
-        dateTime.month,
-        dateTime.day - daysToSubtract,
-      );
-    case TimeGroupBy.month:
-      return DateTime(dateTime.year, dateTime.month);
-  }
-}
-
-DateTime _getNextSegment(DateTime current, TimeGroupBy groupBy) {
-  switch (groupBy) {
-    case TimeGroupBy.hour:
-      return current.add(const Duration(hours: 1));
-    case TimeGroupBy.day:
-      return current.add(const Duration(days: 1));
-    case TimeGroupBy.week:
-      return current.add(const Duration(days: 7));
-    case TimeGroupBy.month:
-      return DateTime(current.year, current.month + 1);
-  }
-}
-
-Map<HealthDataType, double> _aggregateValues(
-  List<AppHealthDataPoint> dataPoints,
-) {
-  if (dataPoints.isEmpty) return {};
-
-  final Map<HealthDataType, List<AppHealthDataPoint>> groupedByType = {};
-  for (final point in dataPoints) {
-    groupedByType
-        .putIfAbsent(
-          HealthDataType.values.firstWhere((type) => type.name == point.type),
-          () => [],
-        )
-        .add(point);
-  }
-
-  final Map<HealthDataType, double> result = {};
-
-  for (final entry in groupedByType.entries) {
-    final HealthDataType dataType = entry.key;
-    final List<AppHealthDataPoint> typeDataPoints = entry.value;
-
-    double total = 0;
-    for (final point in typeDataPoints) {
-      final dynamic value = point.value;
-      if (value is num) {
-        total += value.toDouble();
-      }
-    }
-
-    if (!_isCumulativeDataType(dataType) && typeDataPoints.isNotEmpty) {
-      result[dataType] = total / typeDataPoints.length;
-    } else {
-      result[dataType] = total;
-    }
-  }
-
-  return result;
-}
-
-bool _isCumulativeDataType(HealthDataType dataType) {
-  const cumulativeTypes = {
-    'STEPS',
-    'DISTANCE_DELTA',
-    'ACTIVE_ENERGY_BURNED',
-    'BASAL_ENERGY_BURNED',
-    'WORKOUT',
-    'WATER',
-    'SLEEP_SESSION',
-    'SLEEP_ASLEEP',
-    'SLEEP_AWAKE',
-    'SLEEP_DEEP',
-    'SLEEP_LIGHT',
-    'SLEEP_REM',
-  };
-
-  return cumulativeTypes.contains(dataType.name);
-}
-
-List<AggregatedHealthDataPoint> _buildOverallAverageResponse(
-  HealthDataAggregationParameters aggregationParameters,
-) {
-  double totalValue = 0;
-  int totalDataPoints = 0;
-
-  for (final dataPoint in aggregationParameters.aggregatedData) {
-    final value = dataPoint.value;
-    const dataPointCount = 1;
-
-    totalValue += value;
-    totalDataPoints += dataPointCount;
-  }
-
-  final overallAverage = totalDataPoints > 0
-      ? totalValue / aggregationParameters.aggregatedData.length
-      : 0.0;
-
-  return [
-    AggregatedHealthDataPoint(
-      type: aggregationParameters.formattedData.isNotEmpty
-          ? aggregationParameters.formattedData.first.type
-          : 'UNKNOWN',
-      value: overallAverage,
-      unit: aggregationParameters.formattedData.isNotEmpty
-          ? aggregationParameters.formattedData.first.unit
-          : 'NO_UNIT',
-      dateFrom: aggregationParameters.startTime.toIso8601String(),
-      dateTo: aggregationParameters.endTime.toIso8601String(),
-    ),
-  ];
-}
-
-List<AggregatedHealthDataPoint> _buildAggregatedStatisticsResponse(
-  List<AggregatedHealthDataPoint> aggregatedData,
-  StatisticType statisticType,
-) =>
-    aggregatedData;
-
-HealthDataResponse _createSuccessResponse(
-  List<AppHealthDataPoint> healthData,
-  HealthDataRequest request,
-) {
-  final isAggregated =
-      healthData.all((point) => point is AggregatedHealthDataPoint);
-  return HealthDataResponse(
-    success: true,
-    count: healthData.length,
-    healthData: healthData,
-    valueType: request.valueType.name,
-    startTime: request.startTime.toIso8601String(),
-    endTime: request.endTime.toIso8601String(),
-    groupBy: isAggregated ? request.groupBy?.name : null,
-    isAggregated: isAggregated,
-    statisticType: isAggregated ? request.statistic?.name : null,
-  );
 }

--- a/mobile/lib/core/service/health_data_manager.dart
+++ b/mobile/lib/core/service/health_data_manager.dart
@@ -64,11 +64,13 @@ class HealthDataManager {
     } else {
       final StatisticType? statisticType = request.statistic;
       final aggregatedData = _healthDataAggregator.aggregate(
-        data: dataPoints,
-        groupBy: groupBy,
-        startTime: startTime,
-        endTime: endTime,
-        aggregatePerSource: _aggregatePerSource,
+        (
+          data: dataPoints,
+          groupBy: groupBy,
+          startTime: startTime,
+          endTime: endTime,
+          aggregatePerSource: _aggregatePerSource,
+        ),
       );
 
       switch (statisticType) {


### PR DESCRIPTION
This pull request introduces a set of new utilities and updates for handling health data aggregation, mapping, permissions, and normalization in the mobile core health module. The main changes include the addition of several new classes for health data processing, as well as updates to the `AppHealthDataPoint` model to support a new `sourceId` field. These improvements enable more robust aggregation by source, advanced sleep session normalization, and better permission handling for health data access.

**Health Data Processing Utilities**

* Added `HealthDataAggregator` class in `health_data_aggregator.dart`, which provides methods to aggregate health data points by time segments, type, and source, supporting various temporal behaviors (instantaneous, cumulative, sessional, durational).
* Added `HealthDataMapper` class in `health_data_mapper.dart` to map raw health data points into the app's internal format, including value formatting and source ID extraction.
* Added `HealthSleepSessionNormalizer` class in `health_sleep_session_normalizer.dart`, which consolidates and normalizes overlapping or adjacent sleep sessions from the same source using configurable strategies.

**Health Permissions Handling**

* Added `HealthPermissionsGuard` class in `health_permissions_guard.dart` to ensure required permissions are granted for health data access, including platform-specific checks and history authorization.

**Model Updates**

* Updated `AppHealthDataPoint` model and its generated code to include a new nullable `sourceId` field for both raw and aggregated data points, enabling aggregation and normalization by data source. [[1]](diffhunk://#diff-a2a9702712d4370b7281383134bd708951b8f7d109e2a6f4854fb771f23ac5efR14) [[2]](diffhunk://#diff-a2a9702712d4370b7281383134bd708951b8f7d109e2a6f4854fb771f23ac5efR23) [[3]](diffhunk://#diff-19f65721a32d08e3b13dc37b13a1fd5c4aa251935a1c227a1c0f2a5b77f3567dR37-R64) [[4]](diffhunk://#diff-19f65721a32d08e3b13dc37b13a1fd5c4aa251935a1c227a1c0f2a5b77f3567dL99-R105) [[5]](diffhunk://#diff-19f65721a32d08e3b13dc37b13a1fd5c4aa251935a1c227a1c0f2a5b77f3567dR125)