### PR TITLE
feat: add analytics tracking for health permissions, MCP connection, and health data events

### DIFF
--- a/mobile/lib/core/common/analytics_manager.dart
+++ b/mobile/lib/core/common/analytics_manager.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter_template/core/common/config.dart';
+import 'package:flutter_template/core/common/logger.dart';
+import 'package:flutter_template/core/model/health_data_request.dart';
+import 'package:flutter_template/core/model/health_data_response.dart';
+
+abstract interface class AnalyticsManager {
+  static final AnalyticsService _service = _FirebaseAnalyticsService();
+
+  static Future<void> setCollectionEnabled(bool enabled) async {
+    try {
+      await _service.setCollectionEnabled(enabled);
+    } catch (error, stackTrace) {
+      Logger.w(
+        'Failed to update analytics collection state: $error',
+        error,
+        stackTrace,
+      );
+    }
+  }
+
+  static Future<void> logScreenView(String screenName) async {
+    if (!_shouldLogEvents) {
+      return;
+    }
+
+    try {
+      await _service.logScreenView(screenName);
+    } catch (error, stackTrace) {
+      Logger.w(
+        'Failed to log screen view for $screenName: $error',
+        error,
+        stackTrace,
+      );
+    }
+  }
+
+  static void logHealthDataRequest(HealthDataRequest request) => _logEvent(
+        _AnalyticsEvent.healthDataRequest,
+        {
+          'value_type': request.valueType,
+          'start_time': request.startTime.toIso8601String(),
+          'end_time': request.endTime.toIso8601String(),
+          'group_by': request.groupBy,
+          'statistic': request.statistic,
+        },
+      ).ignore();
+
+  static void logHealthDataResponse(
+    HealthDataResponse response,
+  ) =>
+      _logEvent(
+        _AnalyticsEvent.healthDataResponse,
+        {
+          'value_type': response.valueType,
+          'count': response.count,
+          'is_aggregated': response.isAggregated,
+          'group_by': response.groupBy,
+          'statistic': response.statisticType,
+        },
+      ).ignore();
+
+  static void logHealthDataError({
+    required String valueType,
+    required String errorType,
+    required String errorMessage,
+  }) =>
+      _logEvent(
+        _AnalyticsEvent.healthDataError,
+        {
+          'value_type': valueType,
+          'error_type': errorType,
+          'error_message': errorMessage,
+        },
+      ).ignore();
+
+  static void logMcpConnectionStarted() =>
+      _logEvent(_AnalyticsEvent.mcpConnectionStarted).ignore();
+
+  static void logMcpConnectionError({required String errorMessage}) =>
+      _logEvent(
+        _AnalyticsEvent.mcpConnectionError,
+        {
+          'error_message': errorMessage,
+        },
+      ).ignore();
+
+  static void logMcpConnectionLost() =>
+      _logEvent(_AnalyticsEvent.mcpConnectionLost).ignore();
+
+  static void logHealthPermissionsRequested() =>
+      _logEvent(_AnalyticsEvent.healthPermissionsRequested).ignore();
+
+  static void logHealthPermissionsResult({
+    required bool granted,
+  }) =>
+      _logEvent(
+        _AnalyticsEvent.healthPermissionsResult,
+        {
+          'granted': granted,
+        },
+      ).ignore();
+
+  static bool get _shouldLogEvents => !Config.testingMode;
+
+  static Future<void> _logEvent(
+    _AnalyticsEvent event, [
+    Map<String, Object?> parameters = const {},
+  ]) async {
+    if (!_shouldLogEvents) {
+      return;
+    }
+
+    final sanitizedParameters = Map.fromEntries(
+      parameters.entries.where((e) => e.value != null)
+          as Iterable<MapEntry<String, Object>>,
+    );
+    try {
+      await _service.logEvent(event.analyticsName, sanitizedParameters);
+    } catch (error, stackTrace) {
+      Logger.w(
+        'Failed to log ${event.analyticsName} analytics event: $error',
+        error,
+        stackTrace,
+      );
+    }
+  }
+}
+
+abstract interface class AnalyticsService {
+  Future<void> setCollectionEnabled(bool enabled);
+
+  Future<void> logScreenView(String screenName);
+
+  Future<void> logEvent(String name, Map<String, Object> parameters);
+}
+
+enum _AnalyticsEvent {
+  healthDataRequest('health_data_request'),
+  healthDataResponse('health_data_response'),
+  healthDataError('health_data_error'),
+  mcpConnectionStarted('mcp_connection_started'),
+  mcpConnectionError('mcp_connection_error'),
+  mcpConnectionLost('mcp_connection_lost'),
+  healthPermissionsRequested('health_permissions_requested'),
+  healthPermissionsResult('health_permissions_result');
+
+  const _AnalyticsEvent(this.analyticsName);
+
+  final String analyticsName;
+}
+
+class _FirebaseAnalyticsService implements AnalyticsService {
+  _FirebaseAnalyticsService() : _analytics = FirebaseAnalytics.instance;
+
+  final FirebaseAnalytics _analytics;
+
+  @override
+  Future<void> setCollectionEnabled(bool enabled) =>
+      _analytics.setAnalyticsCollectionEnabled(enabled);
+
+  @override
+  Future<void> logScreenView(String screenName) =>
+      _analytics.logScreenView(screenName: screenName);
+
+  @override
+  Future<void> logEvent(String name, Map<String, Object> parameters) =>
+      _analytics.logEvent(
+        name: name,
+        parameters: parameters,
+      );
+}

--- a/mobile/lib/core/common/logger.dart
+++ b/mobile/lib/core/common/logger.dart
@@ -1,8 +1,6 @@
 import 'dart:developer' as developer;
 
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:flutter_template/core/common/config.dart';
 import 'package:flutter_template/core/common/crash_report_tool.dart';
 import 'package:flutter_template/firebase_options.dart';
 import 'package:logger/logger.dart' as dart_log;
@@ -22,8 +20,6 @@ interface class Logger {
     await Firebase.initializeApp(
       options: await DefaultFirebaseOptions.currentPlatform,
     );
-    await FirebaseAnalytics.instance
-        .setAnalyticsCollectionEnabled(Config.firebaseCollectEventsEnabled);
     await _crashReportTool.init();
   }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_template/core/common/analytics_manager.dart';
 import 'package:flutter_template/core/common/config.dart';
 import 'package:flutter_template/core/common/logger.dart';
 import 'package:flutter_template/core/di/di_provider.dart';
@@ -26,6 +27,9 @@ Future main() async {
 Future initSdks() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Logger.init();
+  await AnalyticsManager.setCollectionEnabled(
+    Config.firebaseCollectEventsEnabled,
+  );
   await Config.initialize();
   await Future.wait([
     DiProvider.init(),

--- a/mobile/lib/ui/home/home_cubit.dart
+++ b/mobile/lib/ui/home/home_cubit.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_template/core/common/analytics_manager.dart';
 import 'package:flutter_template/core/common/config.dart';
 import 'package:flutter_template/core/health_permission_manager.dart';
 import 'package:flutter_template/core/source/mcp_server.dart';
@@ -125,7 +126,15 @@ class HomeCubit extends Cubit<HomeState> {
       healthPermissionManager.hasAllHealthPermissions();
 
   Future<bool> requestHealthPermissions() =>
-      healthPermissionManager.requestHealthPermissions();
+      _requestHealthPermissionsWithTracking();
+
+  Future<bool> _requestHealthPermissionsWithTracking() async {
+    AnalyticsManager.logHealthPermissionsRequested();
+    final permissionsGranted =
+        await healthPermissionManager.requestHealthPermissions();
+    AnalyticsManager.logHealthPermissionsResult(granted: permissionsGranted);
+    return permissionsGranted;
+  }
 
   Future<bool> isHealthConnectInstallationRequired() async =>
       !await healthPermissionManager.isHealthConnectAvailable();

--- a/mobile/lib/ui/router/analytics_observer.dart
+++ b/mobile/lib/ui/router/analytics_observer.dart
@@ -1,23 +1,23 @@
+import 'dart:async';
+
 import 'package:auto_route/auto_route.dart';
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_template/core/common/analytics_manager.dart';
 
 class AnalyticsObserver extends AutoRouterObserver {
   @override
   void didInitTabRoute(TabPageRoute route, TabPageRoute? previousRoute) {
-    FirebaseAnalytics.instance.logScreenView(screenName: route.name);
+    AnalyticsManager.logScreenView(route.name).ignore();
   }
 
   @override
   void didChangeTabRoute(TabPageRoute route, TabPageRoute previousRoute) {
-    FirebaseAnalytics.instance.logScreenView(screenName: route.name);
+    AnalyticsManager.logScreenView(route.name).ignore();
   }
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     if (route.settings.name == null) return;
-    FirebaseAnalytics.instance.logScreenView(
-      screenName: route.settings.name ?? 'unknown',
-    );
+    AnalyticsManager.logScreenView(route.settings.name ?? 'unknown').ignore();
   }
 }


### PR DESCRIPTION
This pull request introduces a centralized analytics management system for the mobile app, replacing direct usage of `FirebaseAnalytics` with a new `AnalyticsManager` abstraction. This refactor improves maintainability, error handling, and enables easier future changes to analytics providers. The changes also add detailed tracking for health data requests, health permission flows, and MCP server connections.

**Analytics Infrastructure Refactor:**

* Added `AnalyticsManager` and `AnalyticsService` abstractions in `core/common/analytics_manager.dart`, encapsulating all analytics event logging and collection state management. This includes robust error handling and event parameter sanitization.
* Removed all direct imports and usages of `FirebaseAnalytics` from various files, including `logger.dart` and `analytics_observer.dart`, migrating event logging to use `AnalyticsManager` methods instead. [[1]](diffhunk://#diff-c41c8dede28ff5b6fdd5b13528dc55495630b638a49669d0ee2e1bd3348428ecL3) [[2]](diffhunk://#diff-dab6b4d3bdb25e9ce447d85d5c60e5a84a66073cf9ed175692b33843f296880dR1-R21)

**Application Event Tracking Enhancements:**

* MCP server connection events now log analytics for connection started, errors, and lost connections, providing better visibility into backend connectivity issues.
* Health data request, response, and error events are now tracked with detailed parameters, improving analytics around health data flows. [[1]](diffhunk://#diff-34d4991af740cec3ce99b8781e059e0706235713cdffd6e08cd4b832b40f6cb9R157-R163) [[2]](diffhunk://#diff-34d4991af740cec3ce99b8781e059e0706235713cdffd6e08cd4b832b40f6cb9R201-R218)
* Health permissions requests and results are now logged via analytics, enabling monitoring of user permission flows.

**App Initialization Changes:**

* Analytics collection state is now set via `AnalyticsManager` during app initialization in `main.dart`, rather than directly through `FirebaseAnalytics`.

**Router Analytics Tracking:**

* All screen view events in `AnalyticsObserver` are now routed through `AnalyticsManager`, ensuring consistent tracking and error handling.